### PR TITLE
Added comment spec file

### DIFF
--- a/sources/2016-09-07-Testing-Logstash-configuration/spec/02_logstash_nginx_filter_spec.rb
+++ b/sources/2016-09-07-Testing-Logstash-configuration/spec/02_logstash_nginx_filter_spec.rb
@@ -13,6 +13,7 @@ describe "Nginx filter" do
   message = "172.17.0.1 - - [05/Sep/2016:20:06:17 +0000] \"GET /images/logos/hubpress.png HTTP/1.1\" 200 5432 \"http://localhost/\" \"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/51.0.2704.79 Chrome/51.0.2704.79 Safari/537.36\" \"-\""
   sample("message" => message, "type" => "nginx") do # <2>
     # Check the ouput event/message properties
+    # Notice that (1), (2) and (3) are annotations and not ruby code
     insist { subject.get("type") } == "nginx" # <3>
     insist { subject.get("@timestamp").to_iso8601 } == "2016-09-05T20:06:17.000Z"
     insist { subject.get("verb") } == "GET"


### PR DESCRIPTION
For people that don't know ruby, it's not that explicit that (1), (2) and (3) are annotations and not ruby code. 
At least when the file is parsed to html.

By adding the comment, it will make it more explicit and may save some headaches